### PR TITLE
Use overflow auto on query list element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -309,7 +309,7 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
             </div>
             <div
               style={{
-                overflow: 'scroll',
+                overflow: 'auto',
               }}
             >
               {queries.map(query => (


### PR DESCRIPTION
Show the scroll bar only when necessary.

Before:

![querytools_overflow_before](https://user-images.githubusercontent.com/3981388/77253348-d20a4900-6c59-11ea-892a-a0ad814ac2a9.png)

After:

![querytools_overflow_after](https://user-images.githubusercontent.com/3981388/77253351-d59dd000-6c59-11ea-9e89-09e6cec6c371.png)

![querytools_overflow_after2](https://user-images.githubusercontent.com/3981388/77253364-e9493680-6c59-11ea-858b-13957e4b4ee9.png)
