### PR TITLE
Use CommonJS syntax only in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 if (process.env.NODE_ENV === 'production') {
   module.exports = {
-    ReactQueryDevtools: () => null,
-    ReactQueryDevtoolsPanel: () => null,
+    ReactQueryDevtools: function() {return null;},
+    ReactQueryDevtoolsPanel: function() {return null;},
   }
 } else {
   module.exports = require('./dist/react-query-devtools.development.js')


### PR DESCRIPTION
index.js now includes fat arrows in production, I believe commonjs is supposed to be in packages to prevent breakage on something like IE11 or other less modern platforms (which is how I came across this)

Not a problem prior to 1.0.4 because dist/react-query-devtools.production.min.js was including (presumably all commonjs compliant)