### PR TITLE
Fix a tag getting shrink

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -456,6 +456,7 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
                       fontWeight: 'bold',
                       textShadow: '0 2px 10px black',
                       background: getQueryStatusColor(activeQuery, theme),
+                      flexShrink: 0,
                     }}
                   >
                     {getQueryStatusLabel(activeQuery)}


### PR DESCRIPTION
A tag shrinks for long queries.

![image](https://user-images.githubusercontent.com/831065/80031935-a7edb600-84a7-11ea-9ab2-37f34c7a0e82.png)
