### PR TITLE
Add types declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,38 @@
+export function ReactQueryDevtools(props: {
+  /**
+   * Set this true if you want the dev tools to default to being open
+   */
+  initialIsOpen?: boolean
+  /**
+   * Use this to add props to the panel. For example, you can add className, style (merge and override default style), etc.
+   */
+  panelProps?: React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  >
+  /**
+   * Use this to add props to the close button. For example, you can add className, style (merge and override default style), onClick (extend default handler), etc.
+   */
+  closeButtonProps?: React.DetailedHTMLProps<
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    HTMLButtonElement
+  >
+  /**
+   * Use this to add props to the toggle button. For example, you can add className, style (merge and override default style), onClick (extend default handler), etc.
+   */
+  toggleButtonProps?: React.DetailedHTMLProps<
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    HTMLButtonElement
+  >
+}): React.ReactElement
+
+export function ReactQueryDevtoolsPanel(props: {
+  /**
+   * The standard React style object used to style a component with inline styles
+   */
+  style?: React.CSSProperties
+  /**
+   * The standard React className property used to style a component with classes
+   */
+  className?: string
+}): React.ReactElement

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "repository": "tannerlinsley/react-query-devtools",
   "main": "index.js",
+  "types": "index.d.ts",
   "sideEffects": false,
   "scripts": {
     "test": "is-ci \"test:ci\" \"test:dev\"",


### PR DESCRIPTION
I created this types definition for `react-query-devtools` in my own project. I thought it would be nice to have it built-in so the others don't have to handle this TS error `Could not find a declaration file for module 'react-query-devtools'.` like I did.