### PR TITLE
Fix for circular json error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,7 @@ export const ReactQueryDevtoolsPanel = React.forwardRef(
 
       return [
         activeQuery,
-        activeQuery ? JSON.parse(JSON.stringify(activeQuery)) : null,
+        activeQuery ? JSON.parse(JSON.stringify(activeQuery, (key, value) => key === 'cache' ? undefined : value)) : null,
       ]
     }, [activeQueryHash, queries])
 


### PR DESCRIPTION
Use replace callback of `JSON.stringify` to ignore `cache` property to prevent circular error.