### PR TITLE
Use useQueryCache

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import match from 'match-sorter'
-import { queryCache, useQueryCache } from 'react-query'
+import { queryCache as cache, useQueryCache } from 'react-query'
 import useLocalStorage from './useLocalStorage'
 
 //
@@ -165,7 +165,7 @@ const sortFns = {
 export const ReactQueryDevtoolsPanel = React.forwardRef(
   function ReactQueryDevtoolsPanel(props, ref) {
 
-    const queryCache = useQueryCache ? useQueryCache() : queryCache;
+    const queryCache = useQueryCache ? useQueryCache() : cache;
 
     const [sort, setSort] = useLocalStorage(
       'reactQueryDevtoolsSortFn',

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import match from 'match-sorter'
-import { useQueryCache } from 'react-query'
+import { queryCache, useQueryCache } from 'react-query'
 import useLocalStorage from './useLocalStorage'
 
 //
@@ -165,7 +165,7 @@ const sortFns = {
 export const ReactQueryDevtoolsPanel = React.forwardRef(
   function ReactQueryDevtoolsPanel(props, ref) {
 
-    const queryCache = useQueryCache();
+    const queryCache = useQueryCache ? useQueryCache() : queryCache;
 
     const [sort, setSort] = useLocalStorage(
       'reactQueryDevtoolsSortFn',

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import match from 'match-sorter'
-import { queryCache } from 'react-query'
+import { useQueryCache } from 'react-query'
 import useLocalStorage from './useLocalStorage'
 
 //
@@ -164,6 +164,9 @@ const sortFns = {
 
 export const ReactQueryDevtoolsPanel = React.forwardRef(
   function ReactQueryDevtoolsPanel(props, ref) {
+
+    const queryCache = useQueryCache();
+
     const [sort, setSort] = useLocalStorage(
       'reactQueryDevtoolsSortFn',
       Object.keys(sortFns)[0]


### PR DESCRIPTION
Uses useQueryCache instead of the default cache to enable the dev tools if useQuery is used throughout the code base.

This will show now all queries in the dev-tools instead of only the queries not wrapped in a CacheProvider.

