### PR TITLE
docs: fix default button position

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ function App() {
 - `toggleButtonProps: PropsObject`
   - Use this to add props to the toggle button. For example, you can add `className`, `style` (merge and override default style), `onClick` (extend default handler), etc.
 - `position?: "top-left" | "top-right" | "bottom-left" | "bottom-right"`
-  - Defaults to `bottom-right`
+  - Defaults to `bottom-left`
   - The position of the React Query logo to open and close the devtools panel
 
 ## Embedded Mode


### PR DESCRIPTION
[looks like](https://github.com/tannerlinsley/react-query-devtools/blob/92088b4af426e9e72fe5cf721207175719e08109/src/index.js#L46) the default button position is actually bottom-left?