### PR TITLE
chore: remove logo height, move aria-label

### DIFF
--- a/src/Logo.js
+++ b/src/Logo.js
@@ -2,7 +2,13 @@ import * as React from 'react'
 
 export default function Logo(props) {
   return (
-    <svg width="40px" height="40px" viewBox="0 0 190 190" version="1.1">
+    <svg
+      width="40px"
+      height="40px"
+      viewBox="0 0 190 190"
+      version="1.1"
+      {...props}
+    >
       <g
         id="Page-1"
         stroke="none"

--- a/src/index.js
+++ b/src/index.js
@@ -146,6 +146,7 @@ export function ReactQueryDevtools({
       ) : (
         <button
           {...otherToggleButtonProps}
+          aria-label="Open React Query Devtools"
           onClick={() => {
             setIsOpen(true)
             onToggleClick && onToggleClick()
@@ -184,11 +185,7 @@ export function ReactQueryDevtools({
             ...toggleButtonStyle,
           }}
         >
-          <Logo
-            width="1.5em"
-            height="1.5em"
-            aria-label="Open React Query Devtools"
-          />
+          <Logo aria-hidden />
         </button>
       )}
     </div>


### PR DESCRIPTION
https://github.com/tannerlinsley/react-query-devtools/commit/b10a9622211d45013bdcea5be5c712fb4880160c updated the togglebutton logo to a [fixed 40px size](https://github.com/tannerlinsley/react-query-devtools/blob/92088b4af426e9e72fe5cf721207175719e08109/src/Logo.js#L5), so we can remove width/height logo props. also: move aria-label to `<button>`