### PR TITLE
fix: query button full height and unused props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -156,8 +156,6 @@ export function ReactQueryDevtools({
             border: 0,
             padding: 0,
             position: 'fixed',
-            bottom: '0',
-            right: '0',
             zIndex: '99999',
             display: 'inline-flex',
             fontSize: '1.5rem',


### PR DESCRIPTION

<img width="728" alt="Screenshot 2020-07-26 at 10 25 53 AM" src="https://user-images.githubusercontent.com/20707504/88471838-23d61f00-cf2b-11ea-83ec-46008df25e52.png">
query button has the full height for top-right and top-left positions, causes a problem with other fixed buttons(next pre-render button) during development.

