### PR TITLE
Fixed toggle button taking full width on Safari

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -166,6 +166,7 @@ export function ReactQueryDevtools({
             fontSize: '1.5rem',
             margin: '.5rem',
             cursor: 'pointer',
+            width: 'fit-content',
             ...(position === 'top-right'
               ? {
                   top: '0',


### PR DESCRIPTION
fixes #66 

I added `width: 'fit-content'` on toggle button to prevent full width on Safari